### PR TITLE
Convert versions to semver compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ app.use(versionRequest.setVersionByAcceptHeader(customParsingFunction))
 Before setting the version, it is always formatted, so the resulting version is a semver comaptible string, except the following cases:
 
 * if the version was set as an Object, it will be returned in stringified format (using JSON.stringify)
-* if the version has a longer format than the semver format, we attept to clean it up by removing the zeros (e.g. 1.0.0.1 will become 1.0.1), but if there are no more zeros to remove, we leave it as it is (e.g. 1.0.1.1.1 will become 1.1.1.1)
+* if the version is longer than the semver format, we truncate it by cutting off the tail, and leaving the first three segments (e.g.: 1.2.3.4.5 will become 1.2.3)
 * if we encunter something, that can't be parsed or formatted as a version, undefined is returned
 
 This formatting function is called automatically for each version setting method, but it can also be used independently:

--- a/README.md
+++ b/README.md
@@ -104,6 +104,18 @@ function customParsingFunction(header) {
 
 app.use(versionRequest.setVersionByAcceptHeader(customParsingFunction))
 ```
+#### Version formatting
+Before setting the version, it is always formatted, so the resulting version is a semver comaptible string, except the following cases:
+
+* if the version was set as an Object, it will be returned in stringified format (using JSON.stringify)
+* if the version has a longer format than the semver format, we attept to clean it up by removing the zeros (e.g. 1.0.0.1 will become 1.0.1), but if there are no more zeros to remove, we leave it as it is (e.g. 1.0.1.1.1 will become 1.1.1.1)
+* if we encunter something, that can't be parsed or formatted as a version, undefined is returned
+
+This formatting function is called automatically for each version setting method, but it can also be used independently:
+```js
+const versionRequest = require('express-version-request')
+const formattedVersion = versionRequest.formatVersion(versionThatNeedsFormatting)
+```
 ##### Options
 
 `removeQueryParam`

--- a/index.js
+++ b/index.js
@@ -100,11 +100,7 @@ class versionRequest {
       return ver
     }
     if (split.length > 3) {
-      while (split.length > 3 && ver.indexOf('.0') !== -1) {
-        ver = ver.replace('.0', '')
-        split = ver.split('.')
-      }
-      return ver
+      return split.slice(0, 3).join('.')
     }
   }
 }

--- a/index.js
+++ b/index.js
@@ -89,10 +89,23 @@ class versionRequest {
       return JSON.stringify(version)
     }
     let ver = version.toString()
-    for (let i = ver.split('.').length; i < 3; i++) {
-      ver += '.0'
+    let split = ver.split('.')
+    if (split.length === 3) {
+      return ver
     }
-    return ver
+    if (split.length < 3) {
+      for (let i = split.length; i < 3; i++) {
+        ver += '.0'
+      }
+      return ver
+    }
+    if (split.length > 3) {
+      while (split.length > 3 && ver.indexOf('.0') !== -1) {
+        ver = ver.replace('.0', '')
+        split = ver.split('.')
+      }
+      return ver
+    }
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 class versionRequest {
   static setVersion (version) {
     return (req, res, next) => {
-      req.version = version
+      req.version = this.formatVersion(version)
       next()
     }
   }
@@ -12,13 +12,7 @@ class versionRequest {
     return (req, res, next) => {
       if (req && req.headers) {
         const version = (headerName && req.headers[headerName.toLowerCase()]) || req.headers['x-api-version']
-        if (version !== undefined) {
-          if (this.isObject(version)) {
-            req.version = JSON.stringify(version)
-          } else {
-            req.version = version
-          }
-        }
+        req.version = this.formatVersion(version)
       }
 
       next()
@@ -30,11 +24,7 @@ class versionRequest {
       if (req && req.query) {
         const version = (queryParam && req.query[queryParam.toLowerCase()]) || req.query['api-version']
         if (version !== undefined) {
-          if (this.isObject(version)) {
-            req.version = JSON.stringify(version)
-          } else {
-            req.version = version
-          }
+          req.version = this.formatVersion(version)
           if (options && options.removeQueryParam === true) {
             if (queryParam && req.query[queryParam.toLowerCase()]) {
               delete req.query[queryParam.toLowerCase()]
@@ -52,10 +42,7 @@ class versionRequest {
     return (req, res, next) => {
       if (req && req.headers && req.headers.accept) {
         if (customFunction && typeof customFunction === 'function') {
-          req.version = customFunction(req.headers.accept)
-          if (typeof req.version !== 'string') {
-            req.version = this.isObject(req.version) ? JSON.stringify(req.version) : req.version.toString()
-          }
+          req.version = this.formatVersion(customFunction(req.headers.accept))
         } else {
           const params = req.headers.accept.split(';')[1]
           const paramMap = {}
@@ -64,11 +51,11 @@ class versionRequest {
               const keyValue = i.split('=')
               paramMap[this.removeWhitespaces(keyValue[0]).toLowerCase()] = this.removeWhitespaces(keyValue[1])
             }
-            req.version = paramMap.version
+            req.version = this.formatVersion(paramMap.version)
           }
 
           if (req.version === undefined) {
-            req.version = this.setVersionByAcceptFormat(req.headers)
+            req.version = this.formatVersion(this.setVersionByAcceptFormat(req.headers))
           }
         }
       }
@@ -92,6 +79,20 @@ class versionRequest {
 
   static removeWhitespaces (str) {
     return str.replace(/\s/g, '')
+  }
+
+  static formatVersion (version) {
+    if (!version || typeof version === 'function' || version === false) {
+      return undefined
+    }
+    if (typeof version === 'object') {
+      return JSON.stringify(version)
+    }
+    let ver = version.toString()
+    for (let i = ver.split('.').length; i < 3; i++) {
+      ver += '.0'
+    }
+    return ver
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -82,7 +82,7 @@ class versionRequest {
   }
 
   static formatVersion (version) {
-    if (!version || typeof version === 'function' || version === false) {
+    if (!version || typeof version === 'function' || version === true) {
       return undefined
     }
     if (typeof version === 'object') {

--- a/test/formatVersion.test.js
+++ b/test/formatVersion.test.js
@@ -20,14 +20,9 @@ test('it converts and corrects the version, if the input is a number', t => {
   t.is(versionRequest.formatVersion(1.2), '1.2.0')
 })
 
-test('it shold remove .0-s if the version is longer than it should', t => {
-  t.is(versionRequest.formatVersion('1.0.0.0.0.0.1'), '1.0.1')
-  t.is(versionRequest.formatVersion('1.0.0.1.0.0.1'), '1.1.1')
-})
-
-test('it shold remove .0-s if the version is longer than it should, but leave it longer, if it contains no more 0-s', t => {
-  t.is(versionRequest.formatVersion('1.0.1.1.1.0.1'), '1.1.1.1.1')
-  t.is(versionRequest.formatVersion('1.0.0.1.0.0.1.0.0.1'), '1.1.1.1')
+test('it shold truncate the version if its longer than it should be', t => {
+  t.is(versionRequest.formatVersion('1.0.0.0.0.0.1'), '1.0.0')
+  t.is(versionRequest.formatVersion('1.0.1.1.0.0.1'), '1.0.1')
 })
 
 test('it returns undefined, if the input cant be converted into a correct version', t => {

--- a/test/formatVersion.test.js
+++ b/test/formatVersion.test.js
@@ -20,6 +20,16 @@ test('it converts and corrects the version, if the input is a number', t => {
   t.is(versionRequest.formatVersion(1.2), '1.2.0')
 })
 
+test('it shold remove .0-s if the version is longer than it should', t => {
+  t.is(versionRequest.formatVersion('1.0.0.0.0.0.1'), '1.0.1')
+  t.is(versionRequest.formatVersion('1.0.0.1.0.0.1'), '1.1.1')
+})
+
+test('it shold remove .0-s if the version is longer than it should, but leave it longer, if it contains no more 0-s', t => {
+  t.is(versionRequest.formatVersion('1.0.1.1.1.0.1'), '1.1.1.1.1')
+  t.is(versionRequest.formatVersion('1.0.0.1.0.0.1.0.0.1'), '1.1.1.1')
+})
+
 test('it returns undefined, if the input cant be converted into a correct version', t => {
   t.is(versionRequest.formatVersion(undefined), undefined)
   t.is(versionRequest.formatVersion(null), undefined)

--- a/test/formatVersion.test.js
+++ b/test/formatVersion.test.js
@@ -1,0 +1,29 @@
+'use strict'
+
+const test = require('ava')
+const versionRequest = require('../index')
+
+test('it pads a shorter version with two zeros', t => {
+  t.is(versionRequest.formatVersion('2'), '2.0.0')
+})
+
+test('it pads a shorter version with one zero', t => {
+  t.is(versionRequest.formatVersion('2.2'), '2.2.0')
+})
+
+test('it doesnt change the version, if its correctly formatted', t => {
+  t.is(versionRequest.formatVersion('2.2.0'), '2.2.0')
+})
+
+test('it converts and corrects the version, if the input is a number', t => {
+  t.is(versionRequest.formatVersion(1), '1.0.0')
+  t.is(versionRequest.formatVersion(1.2), '1.2.0')
+})
+
+test('it returns undefined, if the input cant be converted into a correct version', t => {
+  t.is(versionRequest.formatVersion(undefined), undefined)
+  t.is(versionRequest.formatVersion(null), undefined)
+  t.is(versionRequest.formatVersion(''), undefined)
+  t.is(versionRequest.formatVersion(0), undefined)
+  t.is(versionRequest.formatVersion(() => {}), undefined)
+})

--- a/test/setVersion.test.js
+++ b/test/setVersion.test.js
@@ -12,7 +12,7 @@ test('we can manually set a specific version to be integer', t => {
 
   const middleware = versionRequest.setVersion(versionNumber)
   middleware(t.context.req, {}, () => {
-    t.is(versionNumber, t.context.req.version)
+    t.is(versionRequest.formatVersion(versionNumber), t.context.req.version)
   })
 })
 
@@ -21,7 +21,7 @@ test('we can manually set a specific version to be string', t => {
 
   const middleware = versionRequest.setVersion(versionNumber)
   middleware(t.context.req, {}, () => {
-    t.is(versionNumber, t.context.req.version)
+    t.is(versionRequest.formatVersion(versionNumber), t.context.req.version)
   })
 })
 
@@ -30,6 +30,6 @@ test('we can manually set a specific version to be object', t => {
 
   const middleware = versionRequest.setVersion(versionNumber)
   middleware(t.context.req, {}, () => {
-    t.is(versionNumber, t.context.req.version)
+    t.is(versionRequest.formatVersion(versionNumber), t.context.req.version)
   })
 })

--- a/test/setVersion.test.js
+++ b/test/setVersion.test.js
@@ -17,11 +17,11 @@ test('we can manually set a specific version to be integer', t => {
 })
 
 test('we can manually set a specific version to be string', t => {
-  const versionNumber = '1'
+  const versionNumber = '1.0.0'
 
   const middleware = versionRequest.setVersion(versionNumber)
   middleware(t.context.req, {}, () => {
-    t.is(versionRequest.formatVersion(versionNumber), t.context.req.version)
+    t.is(versionNumber, t.context.req.version)
   })
 })
 
@@ -30,6 +30,6 @@ test('we can manually set a specific version to be object', t => {
 
   const middleware = versionRequest.setVersion(versionNumber)
   middleware(t.context.req, {}, () => {
-    t.is(versionRequest.formatVersion(versionNumber), t.context.req.version)
+    t.is(JSON.stringify(versionNumber), t.context.req.version)
   })
 })

--- a/test/setVersionByAcceptHeader.test.js
+++ b/test/setVersionByAcceptHeader.test.js
@@ -16,7 +16,7 @@ test('we can set the version using the Accept header version field', t => {
   const middleware = versionRequest.setVersionByAcceptHeader()
 
   middleware(t.context.req, {}, () => {
-    t.deepEqual(t.context.req.version, versionNumber)
+    t.deepEqual(t.context.req.version, versionRequest.formatVersion(versionNumber))
   })
 })
 
@@ -27,7 +27,7 @@ test('we can set the version using the Accept header version field, even if we h
   const middleware = versionRequest.setVersionByAcceptHeader()
 
   middleware(t.context.req, {}, () => {
-    t.deepEqual(t.context.req.version, versionNumber)
+    t.deepEqual(t.context.req.version, versionRequest.formatVersion(versionNumber))
   })
 })
 
@@ -38,7 +38,7 @@ test('we can set the version using the Accept header version field, even if it h
   const middleware = versionRequest.setVersionByAcceptHeader()
 
   middleware(t.context.req, {}, () => {
-    t.deepEqual(t.context.req.version, versionNumber)
+    t.deepEqual(t.context.req.version, versionRequest.formatVersion(versionNumber))
   })
 })
 
@@ -49,7 +49,7 @@ test('we can set the version using the Accept header version field, even if it m
   const middleware = versionRequest.setVersionByAcceptHeader()
 
   middleware(t.context.req, {}, () => {
-    t.deepEqual(t.context.req.version, versionNumber)
+    t.deepEqual(t.context.req.version, versionRequest.formatVersion(versionNumber))
   })
 })
 
@@ -89,7 +89,7 @@ test('we can set the version using the Accept header alternative format', t => {
   const middleware = versionRequest.setVersionByAcceptHeader()
 
   middleware(t.context.req, {}, () => {
-    t.deepEqual(t.context.req.version, versionNumber)
+    t.deepEqual(t.context.req.version, versionRequest.formatVersion(versionNumber))
   })
 })
 
@@ -99,7 +99,7 @@ test('we can set the version using the Accept header alternative format, even if
   const headers = { accept: 'application/ vnd.company -v' + versionNumber + ' + json' }
   const resultingVersion = versionRequest.setVersionByAcceptFormat(headers)
 
-  t.deepEqual(resultingVersion, versionNumber)
+  t.deepEqual(resultingVersion, versionRequest.formatVersion(versionNumber))
 })
 
 test('dont set the version, if the alternative format is incorrect', t => {
@@ -118,7 +118,7 @@ test('we can set the version using a custom function to parse the Accept header'
   const middleware = versionRequest.setVersionByAcceptHeader(v => v)
 
   middleware(t.context.req, {}, () => {
-    t.deepEqual(t.context.req.version, versionNumber)
+    t.deepEqual(t.context.req.version, versionRequest.formatVersion(versionNumber))
   })
 })
 
@@ -129,7 +129,7 @@ test('we can handle, if the custom function returns a number', t => {
   const middleware = versionRequest.setVersionByAcceptHeader(v => parseFloat(v))
 
   middleware(t.context.req, {}, () => {
-    t.deepEqual(t.context.req.version, versionNumber)
+    t.deepEqual(t.context.req.version, versionRequest.formatVersion(versionNumber))
   })
 })
 
@@ -140,17 +140,15 @@ test('we can handle, if the custom function returns a boolean', t => {
   const middleware = versionRequest.setVersionByAcceptHeader(v => true)
 
   middleware(t.context.req, {}, () => {
-    t.deepEqual(t.context.req.version, versionNumber)
+    t.deepEqual(t.context.req.version, versionRequest.formatVersion(versionNumber))
   })
 })
 
 test('we can handle, if the custom function returns an object', t => {
-  const versionNumber = '{"alpha":true}'
-
-  t.context.req.headers['accept'] = versionNumber
+  t.context.req.headers['accept'] = 1
   const middleware = versionRequest.setVersionByAcceptHeader(v => { return {alpha: true} })
 
   middleware(t.context.req, {}, () => {
-    t.deepEqual(t.context.req.version, versionNumber)
+    t.deepEqual(t.context.req.version, versionRequest.formatVersion({alpha: true}))
   })
 })

--- a/test/setVersionByAcceptHeader.test.js
+++ b/test/setVersionByAcceptHeader.test.js
@@ -16,7 +16,7 @@ test('we can set the version using the Accept header version field', t => {
   const middleware = versionRequest.setVersionByAcceptHeader()
 
   middleware(t.context.req, {}, () => {
-    t.deepEqual(t.context.req.version, versionRequest.formatVersion(versionNumber))
+    t.deepEqual(t.context.req.version, versionNumber)
   })
 })
 
@@ -27,7 +27,7 @@ test('we can set the version using the Accept header version field, even if we h
   const middleware = versionRequest.setVersionByAcceptHeader()
 
   middleware(t.context.req, {}, () => {
-    t.deepEqual(t.context.req.version, versionRequest.formatVersion(versionNumber))
+    t.deepEqual(t.context.req.version, versionNumber)
   })
 })
 
@@ -38,7 +38,7 @@ test('we can set the version using the Accept header version field, even if it h
   const middleware = versionRequest.setVersionByAcceptHeader()
 
   middleware(t.context.req, {}, () => {
-    t.deepEqual(t.context.req.version, versionRequest.formatVersion(versionNumber))
+    t.deepEqual(t.context.req.version, versionNumber)
   })
 })
 
@@ -89,7 +89,7 @@ test('we can set the version using the Accept header alternative format', t => {
   const middleware = versionRequest.setVersionByAcceptHeader()
 
   middleware(t.context.req, {}, () => {
-    t.deepEqual(t.context.req.version, versionRequest.formatVersion(versionNumber))
+    t.deepEqual(t.context.req.version, versionNumber)
   })
 })
 
@@ -99,7 +99,7 @@ test('we can set the version using the Accept header alternative format, even if
   const headers = { accept: 'application/ vnd.company -v' + versionNumber + ' + json' }
   const resultingVersion = versionRequest.setVersionByAcceptFormat(headers)
 
-  t.deepEqual(resultingVersion, versionRequest.formatVersion(versionNumber))
+  t.deepEqual(resultingVersion, versionNumber)
 })
 
 test('dont set the version, if the alternative format is incorrect', t => {
@@ -118,7 +118,7 @@ test('we can set the version using a custom function to parse the Accept header'
   const middleware = versionRequest.setVersionByAcceptHeader(v => v)
 
   middleware(t.context.req, {}, () => {
-    t.deepEqual(t.context.req.version, versionRequest.formatVersion(versionNumber))
+    t.deepEqual(t.context.req.version, versionNumber)
   })
 })
 
@@ -134,21 +134,22 @@ test('we can handle, if the custom function returns a number', t => {
 })
 
 test('we can handle, if the custom function returns a boolean', t => {
-  const versionNumber = 'true'
+  const versionNumber = true
 
   t.context.req.headers['accept'] = versionNumber
-  const middleware = versionRequest.setVersionByAcceptHeader(v => true)
+  const middleware = versionRequest.setVersionByAcceptHeader(v => versionNumber)
 
   middleware(t.context.req, {}, () => {
-    t.deepEqual(t.context.req.version, versionRequest.formatVersion(versionNumber))
+    t.deepEqual(t.context.req.version, undefined)
   })
 })
 
 test('we can handle, if the custom function returns an object', t => {
+  const versionNumber = {alpha: true}
   t.context.req.headers['accept'] = 1
-  const middleware = versionRequest.setVersionByAcceptHeader(v => { return {alpha: true} })
+  const middleware = versionRequest.setVersionByAcceptHeader(v => { return versionNumber })
 
   middleware(t.context.req, {}, () => {
-    t.deepEqual(t.context.req.version, versionRequest.formatVersion({alpha: true}))
+    t.deepEqual(t.context.req.version, JSON.stringify(versionNumber))
   })
 })

--- a/test/setVersionByHeader.test.js
+++ b/test/setVersionByHeader.test.js
@@ -55,24 +55,24 @@ test('dont set a version if no version header is set', t => {
 })
 
 test('we can set a version on the request object by request headers', t => {
-  const versionNumber = 1
+  const versionNumber = '1.0.0'
 
   t.context.req.headers['x-api-version'] = versionNumber
   const middleware = versionRequest.setVersionByHeader()
 
   middleware(t.context.req, {}, () => {
-    t.is(t.context.req.version, versionRequest.formatVersion(versionNumber))
+    t.is(t.context.req.version, versionNumber)
   })
 })
 
 test('we can manually set a specific version to be string', t => {
-  const versionNumber = '1'
+  const versionNumber = '1.0.0'
 
   t.context.req.headers['x-api-version'] = versionNumber
   const middleware = versionRequest.setVersionByHeader()
 
   middleware(t.context.req, {}, () => {
-    t.is(t.context.req.version, versionRequest.formatVersion(versionNumber))
+    t.is(t.context.req.version, versionNumber)
   })
 })
 
@@ -83,7 +83,7 @@ test('we can manually set a specific version to be object', t => {
   const middleware = versionRequest.setVersionByHeader()
 
   middleware(t.context.req, {}, () => {
-    t.is(t.context.req.version, versionRequest.formatVersion(versionNumber))
+    t.is(t.context.req.version, JSON.stringify(versionNumber))
   })
 })
 
@@ -100,18 +100,18 @@ test('we can set a version on the request object by specifying custom http heade
 })
 
 test('we can set a version on the request object by specifying custom http header as string', t => {
-  const versionNumber = '1'
+  const versionNumber = '1.0.0'
   const versionHeaderName = 'my-api-version-header'
 
   t.context.req.headers[versionHeaderName] = versionNumber
   const middleware = versionRequest.setVersionByHeader(versionHeaderName)
 
   middleware(t.context.req, {}, () => {
-    t.is(t.context.req.version, versionRequest.formatVersion(versionNumber))
+    t.is(t.context.req.version, versionNumber)
   })
 })
 
-test('do not allow to set a version on the request object by specifying custom http header by object', t => {
+test('we can set a version on the request object by specifying custom http header by object', t => {
   const versionNumber = { myVersion: 'alpha' }
   const versionHeaderName = 'my-api-version-header'
 
@@ -119,6 +119,6 @@ test('do not allow to set a version on the request object by specifying custom h
   const middleware = versionRequest.setVersionByHeader(versionHeaderName)
 
   middleware(t.context.req, {}, () => {
-    t.is(t.context.req.version, versionRequest.formatVersion(versionNumber))
+    t.is(t.context.req.version, JSON.stringify(versionNumber))
   })
 })

--- a/test/setVersionByHeader.test.js
+++ b/test/setVersionByHeader.test.js
@@ -36,25 +36,21 @@ test('dont set a version if req object is not well composed: req is undefined', 
 })
 
 test('dont set a version if req object is not well composed: req.headers is undefined', t => {
-  const versionNumber = 1
-
   t.context.req.headers = undefined
   const middleware = versionRequest.setVersionByHeader()
 
   middleware(t.context.req, {}, () => {
     t.is(t.context.req.headers, undefined)
-    t.not(t.context.req.version, versionNumber)
+    t.is(t.context.req.version, undefined)
   })
 })
 
 test('dont set a version if no version header is set', t => {
-  const versionNumber = false
-
   t.context.req.headers = {}
   const middleware = versionRequest.setVersionByHeader()
 
   middleware(t.context.req, {}, () => {
-    t.not(t.context.req.version, versionNumber)
+    t.is(t.context.req.version, undefined)
   })
 })
 
@@ -65,7 +61,7 @@ test('we can set a version on the request object by request headers', t => {
   const middleware = versionRequest.setVersionByHeader()
 
   middleware(t.context.req, {}, () => {
-    t.is(t.context.req.version, versionNumber)
+    t.is(t.context.req.version, versionRequest.formatVersion(versionNumber))
   })
 })
 
@@ -76,7 +72,7 @@ test('we can manually set a specific version to be string', t => {
   const middleware = versionRequest.setVersionByHeader()
 
   middleware(t.context.req, {}, () => {
-    t.is(t.context.req.version, versionNumber)
+    t.is(t.context.req.version, versionRequest.formatVersion(versionNumber))
   })
 })
 
@@ -87,7 +83,7 @@ test('we can manually set a specific version to be object', t => {
   const middleware = versionRequest.setVersionByHeader()
 
   middleware(t.context.req, {}, () => {
-    t.not(t.context.req.version, versionNumber)
+    t.is(t.context.req.version, versionRequest.formatVersion(versionNumber))
   })
 })
 
@@ -99,7 +95,7 @@ test('we can set a version on the request object by specifying custom http heade
   const middleware = versionRequest.setVersionByHeader(versionHeaderName)
 
   middleware(t.context.req, {}, () => {
-    t.is(t.context.req.version, versionNumber)
+    t.is(t.context.req.version, versionRequest.formatVersion(versionNumber))
   })
 })
 
@@ -111,7 +107,7 @@ test('we can set a version on the request object by specifying custom http heade
   const middleware = versionRequest.setVersionByHeader(versionHeaderName)
 
   middleware(t.context.req, {}, () => {
-    t.is(t.context.req.version, versionNumber)
+    t.is(t.context.req.version, versionRequest.formatVersion(versionNumber))
   })
 })
 
@@ -123,6 +119,6 @@ test('do not allow to set a version on the request object by specifying custom h
   const middleware = versionRequest.setVersionByHeader(versionHeaderName)
 
   middleware(t.context.req, {}, () => {
-    t.not(t.context.req.version, versionNumber)
+    t.is(t.context.req.version, versionRequest.formatVersion(versionNumber))
   })
 })

--- a/test/setVersionByQueryParam.test.js
+++ b/test/setVersionByQueryParam.test.js
@@ -34,13 +34,12 @@ test('dont set a version if req object is not well composed: req is undefined', 
 })
 
 test('dont set a version if req object is not well composed: req.query is undefined', t => {
-  const versionNumber = 1
   t.context.req.query = undefined
   const middleware = versionRequest.setVersionByQueryParam()
 
   middleware(t.context.req, {}, () => {
     t.is(t.context.req.query, undefined)
-    t.not(t.context.req.version, versionRequest.formatVersion(versionNumber))
+    t.is(t.context.req.version, undefined)
   })
 })
 
@@ -54,18 +53,18 @@ test('dont set a version if no version query is set', t => {
 })
 
 test('we can set a version on the request object by request query parameters', t => {
-  const versionNumber = 1
+  const versionNumber = '1.0.0'
 
   t.context.req.query['api-version'] = versionNumber
   const middleware = versionRequest.setVersionByQueryParam()
 
   middleware(t.context.req, {}, () => {
-    t.is(t.context.req.version, versionRequest.formatVersion(versionNumber))
+    t.is(t.context.req.version, versionNumber)
   })
 })
 
 test('we can manually set a specific version to be string', t => {
-  const versionNumber = '1'
+  const versionNumber = '1.0.0'
 
   t.context.req.query['api-version'] = versionNumber
   const middleware = versionRequest.setVersionByQueryParam()
@@ -82,7 +81,7 @@ test('we can manually set a specific version to be object', t => {
   const middleware = versionRequest.setVersionByQueryParam()
 
   middleware(t.context.req, {}, () => {
-    t.is(t.context.req.version, versionRequest.formatVersion(versionNumber))
+    t.is(t.context.req.version, JSON.stringify(versionNumber))
   })
 })
 
@@ -99,7 +98,7 @@ test('we can set a version on the request object by specifying custom http query
 })
 
 test('we can set a version on the request object by specifying custom http query param as string', t => {
-  const versionNumber = '1'
+  const versionNumber = '1.0.0'
   const versionParamName = 'my-api-version-param'
 
   t.context.req.query[versionParamName] = versionNumber
@@ -110,7 +109,7 @@ test('we can set a version on the request object by specifying custom http query
   })
 })
 
-test('do not allow to set a version on the request object by specifying custom http query param by object', t => {
+test('we can set a version on the request object by specifying custom http query param by object', t => {
   const versionNumber = { myVersion: 'alpha' }
   const versionParamName = 'my-api-version-param'
 
@@ -118,12 +117,12 @@ test('do not allow to set a version on the request object by specifying custom h
   const middleware = versionRequest.setVersionByQueryParam(versionParamName)
 
   middleware(t.context.req, {}, () => {
-    t.is(t.context.req.version, versionRequest.formatVersion(versionNumber))
+    t.is(t.context.req.version, JSON.stringify(versionNumber))
   })
 })
 
 test('custom query param should be deleted from req.query after handling it', t => {
-  const versionNumber = 1
+  const versionNumber = '1.0.0'
   const versionParamName = 'my-api-version-param'
   const options = {removeQueryParam: true}
 
@@ -131,20 +130,20 @@ test('custom query param should be deleted from req.query after handling it', t 
   const middleware = versionRequest.setVersionByQueryParam(versionParamName, options)
 
   middleware(t.context.req, {}, () => {
-    t.is(t.context.req.version, versionRequest.formatVersion(versionNumber))
+    t.is(t.context.req.version, versionNumber)
     t.falsy(t.context.req.query.hasOwnProperty(versionParamName))
   })
 })
 
 test('default query param should be deleted from req.query after handling it', t => {
-  const versionNumber = 1
+  const versionNumber = '1.0.0'
   const options = {removeQueryParam: true}
 
   t.context.req.query['api-version'] = versionNumber
   const middleware = versionRequest.setVersionByQueryParam(null, options)
 
   middleware(t.context.req, {}, () => {
-    t.is(t.context.req.version, versionRequest.formatVersion(versionNumber))
+    t.is(t.context.req.version, versionNumber)
     t.falsy(t.context.req.query.hasOwnProperty('api-version'))
   })
 })

--- a/test/setVersionByQueryParam.test.js
+++ b/test/setVersionByQueryParam.test.js
@@ -40,18 +40,16 @@ test('dont set a version if req object is not well composed: req.query is undefi
 
   middleware(t.context.req, {}, () => {
     t.is(t.context.req.query, undefined)
-    t.not(t.context.req.version, versionNumber)
+    t.not(t.context.req.version, versionRequest.formatVersion(versionNumber))
   })
 })
 
 test('dont set a version if no version query is set', t => {
-  const versionNumber = false
-
   t.context.req.query = {}
   const middleware = versionRequest.setVersionByQueryParam()
 
   middleware(t.context.req, {}, () => {
-    t.not(t.context.req.version, versionNumber)
+    t.is(t.context.req.version, undefined)
   })
 })
 
@@ -62,10 +60,9 @@ test('we can set a version on the request object by request query parameters', t
   const middleware = versionRequest.setVersionByQueryParam()
 
   middleware(t.context.req, {}, () => {
-    t.is(t.context.req.version, versionNumber)
+    t.is(t.context.req.version, versionRequest.formatVersion(versionNumber))
   })
 })
-
 
 test('we can manually set a specific version to be string', t => {
   const versionNumber = '1'
@@ -74,7 +71,7 @@ test('we can manually set a specific version to be string', t => {
   const middleware = versionRequest.setVersionByQueryParam()
 
   middleware(t.context.req, {}, () => {
-    t.is(t.context.req.version, versionNumber)
+    t.is(t.context.req.version, versionRequest.formatVersion(versionNumber))
   })
 })
 
@@ -85,7 +82,7 @@ test('we can manually set a specific version to be object', t => {
   const middleware = versionRequest.setVersionByQueryParam()
 
   middleware(t.context.req, {}, () => {
-    t.not(t.context.req.version, versionNumber)
+    t.is(t.context.req.version, versionRequest.formatVersion(versionNumber))
   })
 })
 
@@ -97,7 +94,7 @@ test('we can set a version on the request object by specifying custom http query
   const middleware = versionRequest.setVersionByQueryParam(versionParamName)
 
   middleware(t.context.req, {}, () => {
-    t.is(t.context.req.version, versionNumber)
+    t.is(t.context.req.version, versionRequest.formatVersion(versionNumber))
   })
 })
 
@@ -109,7 +106,7 @@ test('we can set a version on the request object by specifying custom http query
   const middleware = versionRequest.setVersionByQueryParam(versionParamName)
 
   middleware(t.context.req, {}, () => {
-    t.is(t.context.req.version, versionNumber)
+    t.is(t.context.req.version, versionRequest.formatVersion(versionNumber))
   })
 })
 
@@ -121,7 +118,7 @@ test('do not allow to set a version on the request object by specifying custom h
   const middleware = versionRequest.setVersionByQueryParam(versionParamName)
 
   middleware(t.context.req, {}, () => {
-    t.not(t.context.req.version, versionNumber)
+    t.is(t.context.req.version, versionRequest.formatVersion(versionNumber))
   })
 })
 
@@ -134,7 +131,7 @@ test('custom query param should be deleted from req.query after handling it', t 
   const middleware = versionRequest.setVersionByQueryParam(versionParamName, options)
 
   middleware(t.context.req, {}, () => {
-    t.is(t.context.req.version, versionNumber)
+    t.is(t.context.req.version, versionRequest.formatVersion(versionNumber))
     t.falsy(t.context.req.query.hasOwnProperty(versionParamName))
   })
 })
@@ -147,7 +144,7 @@ test('default query param should be deleted from req.query after handling it', t
   const middleware = versionRequest.setVersionByQueryParam(null, options)
 
   middleware(t.context.req, {}, () => {
-    t.is(t.context.req.version, versionNumber)
+    t.is(t.context.req.version, versionRequest.formatVersion(versionNumber))
     t.falsy(t.context.req.query.hasOwnProperty('api-version'))
   })
 })


### PR DESCRIPTION
Padding shorter versions happens by adding .0-s to the end.
NEEDS REVIEW: Shortening longer versions is done by removing the .0-s until it's semver compatible, or there are no more .0-s to remove. 