### PR TITLE
Unit test cleanup

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,8 +48,50 @@ class versionRequest {
     }
   }
 
+  static setVersionByAcceptHeader (customFunction) {
+    return (req, res, next) => {
+      if (req && req.headers && req.headers.accept) {
+        if (customFunction && typeof customFunction === 'function') {
+          req.version = customFunction(req.headers.accept)
+          if (typeof req.version !== 'string') {
+            req.version = this.isObject(req.version) ? JSON.stringify(req.version) : req.version.toString()
+          }
+        } else {
+          const params = req.headers.accept.split(';')[1]
+          const paramMap = {}
+          if (params) {
+            for (let i of params.split(',')) {
+              const keyValue = i.split('=')
+              paramMap[this.removeWhitespaces(keyValue[0]).toLowerCase()] = this.removeWhitespaces(keyValue[1])
+            }
+            req.version = paramMap.version
+          }
+
+          if (req.version === undefined) {
+            req.version = this.setVersionByAcceptFormat(req.headers)
+          }
+        }
+      }
+
+      next()
+    }
+  }
+
+  static setVersionByAcceptFormat (headers) {
+    const header = this.removeWhitespaces(headers.accept)
+    const start = header.indexOf('-v')
+    const end = header.indexOf('+')
+    if (start !== -1 && end !== -1) {
+      return header.slice(start + 2, end)
+    }
+  }
+
   static isObject (variable) {
     return typeof variable === 'object' || typeof variable === 'function'
+  }
+
+  static removeWhitespaces (str) {
+    return str.replace(/\s/g, '')
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "eslint-plugin-security": "^1.3.0",
     "nyc": "^10.1.2",
     "opn-cli": "^3.1.0",
-    "standard": "^10.0.2"
+    "standard": "^10.0.2",
+    "sinon": "^1.17.5"
   },
   "nyc": {
     "statements": 90,

--- a/test/setVersion.test.js
+++ b/test/setVersion.test.js
@@ -14,6 +14,7 @@ test('we can manually set a specific version to be integer', t => {
 
   const middleware = versionRequest.setVersion(versionNumber)
   middleware(t.context.req, {}, () => {
+    t.is(t.context.req.version, versionNumber + '.0.0')
     t.is(versionRequestSpy.called, true)
   })
 

--- a/test/setVersion.test.js
+++ b/test/setVersion.test.js
@@ -2,6 +2,7 @@
 
 const test = require('ava')
 const versionRequest = require('../index')
+const sinon = require('sinon')
 
 test.beforeEach(t => {
   t.context.req = {}
@@ -9,11 +10,14 @@ test.beforeEach(t => {
 
 test('we can manually set a specific version to be integer', t => {
   const versionNumber = 1
+  const versionRequestSpy = sinon.spy(versionRequest, 'formatVersion')
 
   const middleware = versionRequest.setVersion(versionNumber)
   middleware(t.context.req, {}, () => {
-    t.is(versionRequest.formatVersion(versionNumber), t.context.req.version)
+    t.is(versionRequestSpy.called, true)
   })
+
+  versionRequestSpy.restore()
 })
 
 test('we can manually set a specific version to be string', t => {

--- a/test/setVersionByAcceptHeader.test.js
+++ b/test/setVersionByAcceptHeader.test.js
@@ -2,6 +2,7 @@
 
 const test = require('ava')
 const versionRequest = require('../index')
+const sinon = require('sinon')
 
 test.beforeEach(t => {
   t.context.req = {
@@ -49,7 +50,7 @@ test('we can set the version using the Accept header version field, even if it m
   const middleware = versionRequest.setVersionByAcceptHeader()
 
   middleware(t.context.req, {}, () => {
-    t.deepEqual(t.context.req.version, versionRequest.formatVersion(versionNumber))
+    t.deepEqual(t.context.req.version, versionNumber)
   })
 })
 
@@ -124,13 +125,16 @@ test('we can set the version using a custom function to parse the Accept header'
 
 test('we can handle, if the custom function returns a number', t => {
   const versionNumber = '1.1'
+  const versionRequestSpy = sinon.spy(versionRequest, 'formatVersion')
 
   t.context.req.headers['accept'] = versionNumber
   const middleware = versionRequest.setVersionByAcceptHeader(v => parseFloat(v))
 
   middleware(t.context.req, {}, () => {
-    t.deepEqual(t.context.req.version, versionRequest.formatVersion(versionNumber))
+    t.deepEqual(t.context.req.version, versionNumber + '.0')
+    t.is(versionRequestSpy.called, true)
   })
+  versionRequestSpy.restore()
 })
 
 test('we can handle, if the custom function returns a boolean', t => {

--- a/test/setVersionByAcceptHeader.test.js
+++ b/test/setVersionByAcceptHeader.test.js
@@ -1,0 +1,156 @@
+'use strict'
+
+const test = require('ava')
+const versionRequest = require('../index')
+
+test.beforeEach(t => {
+  t.context.req = {
+    headers: {}
+  }
+})
+
+test('we can set the version using the Accept header version field', t => {
+  const versionNumber = '1.0.0'
+
+  t.context.req.headers['accept'] = 'application/vnd.company+json;version=' + versionNumber
+  const middleware = versionRequest.setVersionByAcceptHeader()
+
+  middleware(t.context.req, {}, () => {
+    t.deepEqual(t.context.req.version, versionNumber)
+  })
+})
+
+test('we can set the version using the Accept header version field, even if we have multiple parameters', t => {
+  const versionNumber = '1.0.0'
+
+  t.context.req.headers['accept'] = 'application/vnd.company+json;param1=1,version=' + versionNumber + ', param3=3'
+  const middleware = versionRequest.setVersionByAcceptHeader()
+
+  middleware(t.context.req, {}, () => {
+    t.deepEqual(t.context.req.version, versionNumber)
+  })
+})
+
+test('we can set the version using the Accept header version field, even if it has funky whitespaces', t => {
+  const versionNumber = '1.0.0'
+
+  t.context.req.headers['accept'] = 'application/vnd.company+json; param1=1,      version =' + versionNumber + '  , param3=3'
+  const middleware = versionRequest.setVersionByAcceptHeader()
+
+  middleware(t.context.req, {}, () => {
+    t.deepEqual(t.context.req.version, versionNumber)
+  })
+})
+
+test('we can set the version using the Accept header version field, even if it mixes lower- and uppercase characters', t => {
+  const versionNumber = '1.0.0'
+
+  t.context.req.headers['accept'] = 'application/vnd.company+json; param1=1,      Version =' + versionNumber + '  , param3=3'
+  const middleware = versionRequest.setVersionByAcceptHeader()
+
+  middleware(t.context.req, {}, () => {
+    t.deepEqual(t.context.req.version, versionNumber)
+  })
+})
+
+test('dont set the version if the Accept header has no "version" parameter', t => {
+  t.context.req.headers['accept'] = 'application/vnd.company+json;param1=1, param2=2'
+  const middleware = versionRequest.setVersionByAcceptHeader()
+
+  middleware(t.context.req, {}, () => {
+    t.deepEqual(t.context.req.version, undefined)
+  })
+})
+
+test('dont set the version if the Accept header has no parameters at all', t => {
+  t.context.req.headers['accept'] = 'application/vnd.company+json;'
+  const middleware = versionRequest.setVersionByAcceptHeader()
+
+  middleware(t.context.req, {}, () => {
+    t.deepEqual(t.context.req.version, undefined)
+  })
+})
+
+test('dont set the version if the Accept header has no parameters at all (without ending ;)', t => {
+  t.context.req.headers['accept'] = 'application/vnd.company+json'
+  const middleware = versionRequest.setVersionByAcceptHeader()
+
+  middleware(t.context.req, {}, () => {
+    t.deepEqual(t.context.req.version, undefined)
+  })
+})
+
+//  Alternative format
+
+test('we can set the version using the Accept header alternative format', t => {
+  const versionNumber = '1.0.0'
+
+  t.context.req.headers['accept'] = 'application/vnd.company-v' + versionNumber + '+json'
+  const middleware = versionRequest.setVersionByAcceptHeader()
+
+  middleware(t.context.req, {}, () => {
+    t.deepEqual(t.context.req.version, versionNumber)
+  })
+})
+
+test('we can set the version using the Accept header alternative format, even if it has whitespaces', t => {
+  const versionNumber = '1.0.0'
+
+  const headers = { accept: 'application/ vnd.company -v' + versionNumber + ' + json' }
+  const resultingVersion = versionRequest.setVersionByAcceptFormat(headers)
+
+  t.deepEqual(resultingVersion, versionNumber)
+})
+
+test('dont set the version, if the alternative format is incorrect', t => {
+  const headers = { accept: 'application/ vnd.company -v1.0.0///json' }
+  const resultingVersion = versionRequest.setVersionByAcceptFormat(headers)
+
+  t.deepEqual(resultingVersion, undefined)
+})
+
+//  Custom function
+
+test('we can set the version using a custom function to parse the Accept header', t => {
+  const versionNumber = '1.0.0'
+
+  t.context.req.headers['accept'] = versionNumber
+  const middleware = versionRequest.setVersionByAcceptHeader(v => v)
+
+  middleware(t.context.req, {}, () => {
+    t.deepEqual(t.context.req.version, versionNumber)
+  })
+})
+
+test('we can handle, if the custom function returns a number', t => {
+  const versionNumber = '1.1'
+
+  t.context.req.headers['accept'] = versionNumber
+  const middleware = versionRequest.setVersionByAcceptHeader(v => parseFloat(v))
+
+  middleware(t.context.req, {}, () => {
+    t.deepEqual(t.context.req.version, versionNumber)
+  })
+})
+
+test('we can handle, if the custom function returns a boolean', t => {
+  const versionNumber = 'true'
+
+  t.context.req.headers['accept'] = versionNumber
+  const middleware = versionRequest.setVersionByAcceptHeader(v => true)
+
+  middleware(t.context.req, {}, () => {
+    t.deepEqual(t.context.req.version, versionNumber)
+  })
+})
+
+test('we can handle, if the custom function returns an object', t => {
+  const versionNumber = '{"alpha":true}'
+
+  t.context.req.headers['accept'] = versionNumber
+  const middleware = versionRequest.setVersionByAcceptHeader(v => { return {alpha: true} })
+
+  middleware(t.context.req, {}, () => {
+    t.deepEqual(t.context.req.version, versionNumber)
+  })
+})

--- a/test/setVersionByHeader.test.js
+++ b/test/setVersionByHeader.test.js
@@ -2,6 +2,7 @@
 
 const test = require('ava')
 const versionRequest = require('../index')
+const sinon = require('sinon')
 
 test.beforeEach(t => {
   t.context.req = {
@@ -90,13 +91,16 @@ test('we can manually set a specific version to be object', t => {
 test('we can set a version on the request object by specifying custom http header as integer', t => {
   const versionNumber = 1
   const versionHeaderName = 'my-api-version-header'
+  const versionRequestSpy = sinon.spy(versionRequest, 'formatVersion')
 
   t.context.req.headers[versionHeaderName] = versionNumber
   const middleware = versionRequest.setVersionByHeader(versionHeaderName)
 
   middleware(t.context.req, {}, () => {
-    t.is(t.context.req.version, versionRequest.formatVersion(versionNumber))
+    t.is(t.context.req.version, versionNumber + '.0.0')
+    t.is(versionRequestSpy.called, true)
   })
+  versionRequestSpy.restore()
 })
 
 test('we can set a version on the request object by specifying custom http header as string', t => {

--- a/test/setVersionByHeader.test.js
+++ b/test/setVersionByHeader.test.js
@@ -12,8 +12,6 @@ test.beforeEach(t => {
 })
 
 test('dont set a version if req object is not well composed: req is null', t => {
-  const versionNumber = 1
-
   t.context.req = null
   const middleware = versionRequest.setVersionByHeader()
 
@@ -26,8 +24,6 @@ test('dont set a version if req object is not well composed: req is null', t => 
 })
 
 test('dont set a version if req object is not well composed: req is undefined', t => {
-  const versionNumber = 1
-
   t.context.req = undefined
   const middleware = versionRequest.setVersionByHeader()
 
@@ -72,7 +68,6 @@ test('we can set a version on the request object by request headers', t => {
     t.is(t.context.req.version, versionNumber)
   })
 })
-
 
 test('we can manually set a specific version to be string', t => {
   const versionNumber = '1'

--- a/test/setVersionByQueryParam.test.js
+++ b/test/setVersionByQueryParam.test.js
@@ -2,6 +2,7 @@
 
 const test = require('ava')
 const versionRequest = require('../index')
+const sinon = require('sinon')
 
 test.beforeEach(t => {
   t.context.req = {
@@ -70,7 +71,7 @@ test('we can manually set a specific version to be string', t => {
   const middleware = versionRequest.setVersionByQueryParam()
 
   middleware(t.context.req, {}, () => {
-    t.is(t.context.req.version, versionRequest.formatVersion(versionNumber))
+    t.is(t.context.req.version, versionNumber)
   })
 })
 
@@ -88,13 +89,16 @@ test('we can manually set a specific version to be object', t => {
 test('we can set a version on the request object by specifying custom http query param as integer', t => {
   const versionNumber = 1
   const versionParamName = 'my-api-version-param'
+  const versionRequestSpy = sinon.spy(versionRequest, 'formatVersion')
 
   t.context.req.query[versionParamName] = versionNumber
   const middleware = versionRequest.setVersionByQueryParam(versionParamName)
 
   middleware(t.context.req, {}, () => {
-    t.is(t.context.req.version, versionRequest.formatVersion(versionNumber))
+    t.is(t.context.req.version, versionNumber + '.0.0')
+    t.is(versionRequestSpy.called, true)
   })
+  versionRequestSpy.restore()
 })
 
 test('we can set a version on the request object by specifying custom http query param as string', t => {
@@ -105,7 +109,7 @@ test('we can set a version on the request object by specifying custom http query
   const middleware = versionRequest.setVersionByQueryParam(versionParamName)
 
   middleware(t.context.req, {}, () => {
-    t.is(t.context.req.version, versionRequest.formatVersion(versionNumber))
+    t.is(t.context.req.version, versionNumber)
   })
 })
 


### PR DESCRIPTION
Cleaned up the use of fomratVersion in unit tests. We don't call it directly anymore, we just make sure, that it was called (via a spy) when conversion should be done.