### PR TITLE
feat(add alternative Accept header format '.v') 

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ The second parameter of `setVersionByQueryParam` is an options object.
 ### Set request version by 'Accept' header
 
 By default, the library will parse the version from the Accept header, expecting the following format:
-Accept: application/vnd.company+json;version=1.0.0
+**Accept: application/vnd.company+json;version=1.0.0**
 For more details about the Accept header format, please refer to the [RFC](https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html).
 
 
@@ -81,7 +81,12 @@ app.use(versionRequest.setVersionByAcceptHeader())
 ```
 #### Parsing using an alternative format
 As a fallback, the lib supports an alternative Accept header format:
-Accept: application/vnd.comapny-v1.0.0+json
+
+**Accept: application/vnd.comapny-v1.0.0+json**
+
+or
+
+**Accept: application/vnd.comapny.v1.0.0+json**
 
 The lib will try to parse the header using the default format, and if it doesn't succeed, tries this alternative format.
 The usage is the same as in the case of the regular format:

--- a/index.js
+++ b/index.js
@@ -66,7 +66,10 @@ class versionRequest {
 
   static setVersionByAcceptFormat (headers) {
     const header = this.removeWhitespaces(headers.accept)
-    const start = header.indexOf('-v')
+    let start = header.indexOf('-v')
+    if (start === -1) {
+      start = header.indexOf('.v')
+    }
     const end = header.indexOf('+')
     if (start !== -1 && end !== -1) {
       return header.slice(start + 2, end)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-version-request",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "versions an incoming request to Express based on header or URL",
   "main": "index.js",
   "scripts": {

--- a/test/setVersionByAcceptHeader.test.js
+++ b/test/setVersionByAcceptHeader.test.js
@@ -83,10 +83,21 @@ test('dont set the version if the Accept header has no parameters at all (withou
 
 //  Alternative format
 
-test('we can set the version using the Accept header alternative format', t => {
+test('we can set the version using the Accept header alternative format 1', t => {
   const versionNumber = '1.0.0'
 
   t.context.req.headers['accept'] = 'application/vnd.company-v' + versionNumber + '+json'
+  const middleware = versionRequest.setVersionByAcceptHeader()
+
+  middleware(t.context.req, {}, () => {
+    t.deepEqual(t.context.req.version, versionNumber)
+  })
+})
+
+test('we can set the version using the Accept header alternative format 2', t => {
+  const versionNumber = '1.0.0'
+
+  t.context.req.headers['accept'] = 'application/vnd.company.v' + versionNumber + '+json'
   const middleware = versionRequest.setVersionByAcceptHeader()
 
   middleware(t.context.req, {}, () => {


### PR DESCRIPTION
support 'application/vnd.comapny.v1.0.0+json'